### PR TITLE
Sync skills/integrate-agentforce-ios from internal

### DIFF
--- a/skills/integrate-agentforce-ios/references/dep-manager-detection.md
+++ b/skills/integrate-agentforce-ios/references/dep-manager-detection.md
@@ -60,6 +60,17 @@ target 'YourApp' do
   pod 'AgentforceSDK'
   pod 'Messaging-InApp-Core'   # AgentforceSDK uses a pre-release; pin if you must
   pod 'LiveKitClient'          # ensures CocoaPods picks the right source
+
+  # AgentforceService / AgentforceSDK binaries @rpath-link these SwiftPM-style
+  # modules but the published podspecs don't declare them as dependencies.
+  # Without these the app builds but crashes at launch with
+  # `dyld: Library not loaded: @rpath/<X>.framework/<X>`.
+  pod 'SwiftCrypto'
+  pod 'DequeModule'
+  pod 'OrderedCollections'
+  pod 'InternalCollectionsUtilities'
+  pod 'JWTKit'
+  pod 'Logging'
 end
 
 post_install do |installer|

--- a/skills/integrate-agentforce-ios/references/snippets/AgentforceConsoleLogger.swift
+++ b/skills/integrate-agentforce-ios/references/snippets/AgentforceConsoleLogger.swift
@@ -24,7 +24,7 @@ struct AgentforceConsoleLogger: SalesforceLogging.Logger {
             info.info("\(logMessage, privacy: .public)")
         case .warning:
             warn.warning("\(logMessage, privacy: .public)")
-        case .error, .fault:
+        case .error:
             error.error("\(logMessage, privacy: .public)")
         @unknown default:
             info.log("\(logMessage, privacy: .public)")


### PR DESCRIPTION
Automated sync of `skills/integrate-agentforce-ios` 

## Changes
- **references/dep-manager-detection.md** — add the 6 missing transitive runtime pods (`SwiftCrypto`, `DequeModule`, `OrderedCollections`, `InternalCollectionsUtilities`, `JWTKit`, `Logging`) to the CocoaPods example. These are @rpath-linked by the AgentforceSDK binaries but not declared in the published podspecs, so without them the app builds but crashes at launch with `dyld: Library not loaded`.
- **references/snippets/AgentforceConsoleLogger.swift** — drop `.fault` from the `.error` case (now covered by `@unknown default`).